### PR TITLE
Use configuration file for pylint

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,2 @@
+[FORMAT]
+max-line-length=90

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,7 +36,7 @@ runTheBuilds.runDevToolsProject(
         data.venv.run('pydocstyle -v')
       },
       pylint: {
-        data.venv.run('pylint --max-line-length=90 jenkins_node_scanner.py')
+        data.venv.run('pylint jenkins_node_scanner.py')
       },
       yamllint: {
         data.venv.run('yamllint --strict .travis.yml')

--- a/jenkins_node_scanner.py
+++ b/jenkins_node_scanner.py
@@ -53,7 +53,7 @@ def ignore_exceptions_except_exit():
     """Ignores all exceptions except KeyboardInterrupt and SystemExit."""
     try:
         yield
-    except (KeyboardInterrupt, SystemExit):
+    except (KeyboardInterrupt, SystemExit):  # noqa pylint: disable=try-except-raise
         raise
     except:  # noqa pylint: disable=bare-except
         logging.exception('Unexpected error, continuing anyway.')


### PR DESCRIPTION
The configuration file was generated by `pylint` itself, I only added `try-except-raise` to it to suppress a warning which suddenly showed up in a newer version of pylint. ping @AbletonDevTools/gotham-city 