### PR TITLE
Deploy when FORCE_DEPLOY parameter is true

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -40,7 +40,12 @@ runTheBuilds.runDevToolsProject(
     )
   },
   deploy: { data ->
-    runTheBuilds.withBranches(branches: ['master'], acceptPullRequests: false) {
+    boolean shouldDeploy = env.FORCE_DEPLOY == 'true' ?: false
+    runTheBuilds.withMaster {
+      // Always deploy on the master branch, regardless of the value for FORCE_DEPLOY
+      shouldDeploy = true
+    }
+    if (shouldDeploy) {
       data['dtrImage'].push()
       data['dtrImage'].deploy(
         '8000', '-v jenkins-nodes:/jenkins_nodes', env.CONTAINER_ARGS)


### PR DESCRIPTION
This commit assumes the presence of a FORCE_DEPLOY boolean parameter
in the Jenkins job configuration. When this parameter is true, or when
the build is on the master branch, then the a deployment will be
performed.

---

Related to AbletonAppDev/devtools#1344. ping @AbletonDevTools/gotham-city