### PR TITLE
Use pipenv sync instead of pipenv install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /jenkins_node_scanner
 COPY Pipfile /jenkins_node_scanner
 COPY Pipfile.lock /jenkins_node_scanner
 RUN pip install --no-cache-dir pipenv
-RUN pipenv install --system
+RUN pipenv install --system --ignore-pipfile
 
 COPY jenkins_node_scanner.py /jenkins_node_scanner
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,7 @@
 runTheBuilds.runDevToolsProject(
   setup: { data ->
     data['dtrImage'] = dtr.create('devtools', 'jenkins-node-scanner')
-    sh 'pipenv install --dev'
+    sh 'pipenv sync --dev'
   },
   build: { data ->
     data['dtrImage'].build()

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ about updating dependencies and so on.
 
 Basic usage:
 
-1. `pipenv install`
+1. `pipenv sync`
 1. `pipenv run python jenkins_node_scanner.py http://jenkins:8080 output.json --period 5`
 1. `cat output.json`
 


### PR DESCRIPTION
It turns out that pipenv install is an alias for lock + sync. This
causes the lockfile to be updated, meaning we may not be installing
the packages which we expect.

---

Related to https://github.com/AbletonAppDev/devtools/issues/1715, ping @AbletonDevTools/gotham-city 