### PR TITLE
Don't copy the Pipfile to the Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,6 @@ VOLUME /output
 RUN mkdir -p /jenkins_node_scanner
 WORKDIR /jenkins_node_scanner
 
-COPY Pipfile /jenkins_node_scanner
 COPY Pipfile.lock /jenkins_node_scanner
 RUN pip install --no-cache-dir pipenv
 RUN pipenv install --system --ignore-pipfile


### PR DESCRIPTION
We are actively ignoring the Pipfile when installing pip packages, so
there's no point in copying it to the container.

---

ping @AbletonDevTools/gotham-city 