### PR TITLE
Allow scanning multiple ports on build nodes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -48,7 +48,8 @@ devToolsProject.run(
     data['dtrImage'].deploy(
       '8000',
       '-v jenkins-nodes:/jenkins_nodes',
-      "${env.JENKINS_URL} /jenkins_nodes/output.json",
+      '--target-port 9100 --target-port 9323' +
+        " ${env.JENKINS_URL} /jenkins_nodes/output.json",
     )
   },
   cleanup: {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,7 +42,7 @@ devToolsProject.run(
       },
     )
   },
-  deployWhen: { return runTheBuilds.isPushTo(['master']) || env.FORCE_DEPLOY == 'true'},
+  deployWhen: { return runTheBuilds.isPushTo(['master']) || env.FORCE_DEPLOY == 'true' },
   deploy: { data ->
     data['dtrImage'].push()
     data['dtrImage'].deploy(

--- a/jenkins_node_scanner.py
+++ b/jenkins_node_scanner.py
@@ -89,7 +89,8 @@ def get_args():
         '--period',
         default=60,
         type=int,
-        help='How many seconds to wait between scans.',
+        help='How many seconds to wait between scans. If 0, then the script will exit '
+             'after performing a single scan.',
     )
     parser.add_argument(
         '--prometheus-port',
@@ -230,6 +231,9 @@ def main():
                 } for node, ip in node_ips]
 
                 write_output(args.output_file, node_info)
+
+        if args.period == 0:
+            break
 
         logging.debug('Waiting %d seconds', args.period)
         time.sleep(args.period)

--- a/jenkins_node_scanner.py
+++ b/jenkins_node_scanner.py
@@ -100,9 +100,13 @@ def get_args():
     )
     parser.add_argument(
         '--target-port',
-        default=9100,
+        action='append',
+        default=[],
+        dest='target_ports',
+        required=True,
         type=int,
-        help='Target port to be scraped (e.g. 9100 for node_exporter).',
+        help='Target port to be scraped (e.g. 9100 for node_exporter). May be given '
+             'multiple times for multiple ports.',
     )
     parser.add_argument(
         '--timeout',
@@ -227,8 +231,8 @@ def main():
                         'jenkins_master': args.url,
                         'node': node['name'],
                     },
-                    'targets': ['%s:%d' % (ip, args.target_port)],
-                } for node, ip in node_ips]
+                    'targets': ['%s:%d' % (ip_addr, port) for port in args.target_ports],
+                } for node, ip_addr in node_ips]
 
                 write_output(args.output_file, node_info)
 

--- a/jenkins_node_scanner.py
+++ b/jenkins_node_scanner.py
@@ -9,6 +9,7 @@ import json
 import logging
 import os
 import re
+import shutil
 import sys
 import tempfile
 import time
@@ -179,7 +180,7 @@ def write_output(output_file, node_info):
             filehandle.flush()
             os.fsync(filehandle.fileno())
         # Overwrite output by renaming the tempfile to the output file.
-        os.rename(tmpfile, output_file)
+        shutil.move(tmpfile, output_file)
 
 
 def main():


### PR DESCRIPTION
This PR changes the way that the `jenkins-node-scanner.py` script works with respect to the `--target-port` argument. Specifically, this argument may now be specified multiple times in order to scan multiple ports, and the ports are tested with a basic TCP socket connection to ensure that they are responding. Only ports which are actually active will be added to the generated output file. Also, the `--target-port` argument *must* now be specified at least once, and the default value (previously `9100`) has been removed.

Ping @AbletonDevTools/gotham-city 